### PR TITLE
Add README index

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ This repository contains the core Based Applications Contracts, including UUPS u
   
 &nbsp;
 
-## :page_facing_up: _Whitepaper_
-
-[Whitepaper](https://ssv.network/wp-content/uploads/2025/01/SSV2.0-Based-Applications-Protocol-1.pdf)
-
-&nbsp;
-
 ## :page_with_curl: _Instructions_
 
 **1)** Fire up your favorite console & clone this repo somewhere:
@@ -46,6 +40,18 @@ __`❍ forge build`__
 **4)** Set the tests going!
 
 __`❍ forge test`__
+
+&nbsp;
+
+## :page_facing_up: _Whitepaper_
+
+[Whitepaper](https://ssv.network/wp-content/uploads/2025/01/SSV2.0-Based-Applications-Protocol-1.pdf)
+
+&nbsp;
+
+## :page_facing_up: _More Resources_
+
+[Based Apps Onboarding Guide](./doc/bapp_onboarding.md) 
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # :construction_worker: :closed_lock_with_key: __Based Applications Contracts__
 
+### Intro | [bApp Onboarding Guide](./doc/bapp_onboarding.md) 
+
 :construction: CAUTION: This repo is currently under **heavy development!** :construction:
 
 [![CI Tests](https://github.com/ssvlabs/based-applications/actions/workflows/tests.yml/badge.svg)](https://github.com/ssvlabs/based-applications/actions/workflows/tests.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # :construction_worker: :closed_lock_with_key: __Based Applications Contracts__
 
-### Intro | [bApp Onboarding Guide](./doc/bapp_onboarding.md) 
-
 :construction: CAUTION: This repo is currently under **heavy development!** :construction:
 
 [![CI Tests](https://github.com/ssvlabs/based-applications/actions/workflows/tests.yml/badge.svg)](https://github.com/ssvlabs/based-applications/actions/workflows/tests.yml)

--- a/doc/bapp_onboarding.md
+++ b/doc/bapp_onboarding.md
@@ -1,5 +1,7 @@
 # bApp Onboarding Guide
 
+### [Intro]((../README.md)) | bApp Onboarding Guide 
+
 This guide outlines the steps for based applications developers looking to build on the bApps platform.
 
 ## 1. Creating and Configuring a bApp

--- a/doc/bapp_onboarding.md
+++ b/doc/bapp_onboarding.md
@@ -1,6 +1,6 @@
 # bApp Onboarding Guide
 
-### [Intro]((../README.md)) | bApp Onboarding Guide 
+### [Intro](../README.md) | bApp Onboarding Guide 
 
 This guide outlines the steps for based applications developers looking to build on the bApps platform.
 


### PR DESCRIPTION
To allow visibility to the documentation, let's use the same index pattern as on [SSV Network repo](https://github.com/ssvlabs/ssv-network/blob/main/README.md).