### PR TITLE
Enrich SSVBasedApps interface

### DIFF
--- a/src/core/SSVBasedApps.sol
+++ b/src/core/SSVBasedApps.sol
@@ -59,10 +59,7 @@ import { ProtocolStorageLib } from "@ssv/src/core/libraries/ProtocolStorageLib.s
 contract SSVBasedApps is
     ISSVBasedApps,
     UUPSUpgradeable,
-    Ownable2StepUpgradeable,
-    IBasedAppManager,
-    IStrategyManager,
-    IProtocolManager
+    Ownable2StepUpgradeable
 {
     // ***************************
     // ** Section: Initializers **
@@ -343,9 +340,7 @@ contract SSVBasedApps is
         _delegateTo(SSVCoreModules.SSV_PROTOCOL_MANAGER);
     }
 
-    function updateDisabledFeatures(
-        uint32 disabledFeatures
-    ) external onlyOwner {
+    function updateDisabledFeatures(uint32 value) external onlyOwner {
         _delegateTo(SSVCoreModules.SSV_PROTOCOL_MANAGER);
     }
 

--- a/src/core/interfaces/ISSVBasedApps.sol
+++ b/src/core/interfaces/ISSVBasedApps.sol
@@ -4,16 +4,21 @@ pragma solidity 0.8.29;
 import { IStrategyManager } from "@ssv/src/core/interfaces/IStrategyManager.sol";
 import { IBasedAppManager } from "@ssv/src/core/interfaces/IBasedAppManager.sol";
 import { IProtocolManager } from "@ssv/src/core/interfaces/IProtocolManager.sol";
+import { IViews } from "@ssv/src/core/interfaces/IViews.sol";
 import { SSVCoreModules } from "@ssv/src/core/libraries/CoreStorageLib.sol";
 import { ProtocolStorageLib } from "@ssv/src/core/libraries/ProtocolStorageLib.sol";
 
-interface ISSVBasedApps {
+interface ISSVBasedApps is
+    IStrategyManager,
+    IBasedAppManager,
+    IProtocolManager,
+    IViews
+{
     event ModuleUpdated(SSVCoreModules indexed moduleId, address moduleAddress);
 
     function getModuleAddress(
         SSVCoreModules moduleId
     ) external view returns (address);
-    function getVersion() external pure returns (string memory version);
     function initialize(
         address owner_,
         IBasedAppManager ssvBasedAppManger_,

--- a/src/core/interfaces/IViews.sol
+++ b/src/core/interfaces/IViews.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.29;
+
+interface IViews {
+    function delegations(
+        address account,
+        address receiver
+    ) external view returns (uint32);
+    function totalDelegatedPercentage(
+        address delegator
+    ) external view returns (uint32);
+    function registeredBApps(
+        address bApp
+    ) external view returns (bool isRegistered);
+    function strategies(
+        uint32 strategyId
+    ) external view returns (address strategyOwner, uint32 fee);
+    function ownedStrategies(
+        address owner
+    ) external view returns (uint32[] memory strategyIds);
+    function strategyAccountShares(
+        uint32 strategyId,
+        address account,
+        address token
+    ) external view returns (uint256);
+    function strategyTotalBalance(
+        uint32 strategyId,
+        address token
+    ) external view returns (uint256);
+    function strategyTotalShares(
+        uint32 strategyId,
+        address token
+    ) external view returns (uint256);
+    function strategyGeneration(
+        uint32 strategyId,
+        address token
+    ) external view returns (uint256);
+    function obligations(
+        uint32 strategyId,
+        address bApp,
+        address token
+    ) external view returns (uint32 percentage, bool isSet);
+    function bAppTokens(
+        address bApp,
+        address token
+    )
+        external
+        view
+        returns (
+            uint32 currentValue,
+            bool isSet,
+            uint32 pendingValue,
+            uint32 effectTime
+        );
+    function accountBAppStrategy(
+        address account,
+        address bApp
+    ) external view returns (uint32);
+    function feeUpdateRequests(
+        uint32 strategyId
+    ) external view returns (uint32 percentage, uint32 requestTime);
+    function withdrawalRequests(
+        uint32 strategyId,
+        address account,
+        address token
+    ) external view returns (uint256 shares, uint32 requestTime);
+    function obligationRequests(
+        uint32 strategyId,
+        address token,
+        address bApp
+    ) external view returns (uint32 percentage, uint32 requestTime);
+    function slashingFund(
+        address account,
+        address token
+    ) external view returns (uint256);
+
+    // External Protocol Views
+    function maxPercentage() external pure returns (uint32);
+    function ethAddress() external pure returns (address);
+    function maxShares() external view returns (uint256);
+    function maxFeeIncrement() external view returns (uint32);
+    function feeTimelockPeriod() external view returns (uint32);
+    function feeExpireTime() external view returns (uint32);
+    function withdrawalTimelockPeriod() external view returns (uint32);
+    function withdrawalExpireTime() external view returns (uint32);
+    function obligationTimelockPeriod() external view returns (uint32);
+    function obligationExpireTime() external view returns (uint32);
+    function disabledFeatures() external view returns (uint32);
+    function tokenUpdateTimelockPeriod() external view returns (uint32);
+    function getVersion() external pure returns (string memory);
+}

--- a/test/modules/ProtocolManager.t.sol
+++ b/test/modules/ProtocolManager.t.sol
@@ -220,7 +220,7 @@ contract ProtocolManagerTest is Setup, Ownable2StepUpgradeable {
     }
 
     /// @notice By default, no features should be disabled
-    function testDefaultDisabledFeaturesIsZero() public {
+    function testDefaultDisabledFeaturesIsZero() public view {
         assertEq(
             proxiedManager.disabledFeatures(),
             0,


### PR DESCRIPTION

Function | Description | Inputs | Outputs
-- | -- | -- | --
delegations | Percentage of validator balance that account has delegated to receiver. | address account address receiver | uint32 (percentage)
totalDelegatedPercentage | Total percentage of validator balance that delegator has delegated across all receivers. | address delegator | uint32 (total percentage)
registeredBApps | Whether the given bApp address is registered. | address bApp | bool isRegistered
strategies | Returns the owner and fee of a strategy. | uint32 strategyId | address strategyOwner uint32 fee
ownedStrategies | All strategy IDs owned by owner. | address owner | uint32[] strategyIds
strategyAccountShares | Share‐balance of account in strategyId for token, or 0 if out‐of‐date. | uint32 strategyId address account address token | uint256 (account’s share balance)
strategyTotalBalance | Total token balance held by strategyId for token. | uint32 strategyId address token | uint256 (total token balance)
strategyTotalShares | Total share‐balance issued by strategyId for token. | uint32 strategyId address token | uint256 (total share balance)
strategyGeneration | Current generation counter for strategyId & token. | uint32 strategyId address token | uint256 (generation)
obligations | The obligation % reserved for bApp by strategyId in token. | uint32 strategyId address bApp address token | uint32 percentage, bool isSet
bAppTokens | bApp’s token config: current & pending slashing‐capital % and when it takes effect. | address bApp address token | uint32 currentValue, bool isSet, uint32 pendingValue, uint32 effectTime
accountBAppStrategy | Which strategy account uses for bApp. | address account address bApp | uint32 (strategyId)
feeUpdateRequests | Pending fee‐update % and request timestamp for strategyId. | uint32 strategyId | uint32 percentage, uint32 requestTime
withdrawalRequests | Pending withdrawal in shares & request timestamp for account in strategyId/token. | uint32 
strategyId address accountaddress token | uint256 sharesuint32 requestTime
obligationRequests | Pending obligation % change and request timestamp for strategyId/token/bApp. | uint32 strategyId address token address bApp | uint32 percentage, uint32 requestTime
slashingFund | Amount of token in the slashing fund of account. | address account address token | uint256 (amount)
maxPercentage | The maximum percentage constant (MAX_PERCENTAGE). | — | uint32
ethAddress | Sentinel address used to represent native ETH. | — | address
maxShares | Protocol’s maxShares limit. | — | uint256
maxFeeIncrement | Protocol’s maxFeeIncrement setting. | — | uint32
feeTimelockPeriod | Protocol’s fee‐update timelock period (seconds). | — | uint32
feeExpireTime | Protocol’s fee‐update expiration time (seconds). | — | uint32
withdrawalTimelockPeriod | Protocol’s withdrawal timelock period (seconds). | — | uint32
withdrawalExpireTime | Protocol’s withdrawal expiration time (seconds). | — | uint32
obligationTimelockPeriod | Protocol’s obligation‐update timelock period (seconds). | — | uint32
obligationExpireTime | Protocol’s obligation‐update expiration time (seconds). | — | uint32
disabledFeatures | Bitmask of disabled protocol features. | — | uint32
tokenUpdateTimelockPeriod | Protocol’s bApp‐token update timelock period (seconds). | — | uint32
getVersion | Returns the implementation version string. | — | string

