### PR TITLE
chore(ci) - Update actions base image to node:24

### DIFF
--- a/.github/workflows/foundry-gas-diff.yml
+++ b/.github/workflows/foundry-gas-diff.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1
+        uses: foundry-rs/foundry-toolchain@v1.7.0 # v1
         with:
           version: nightly
 
@@ -28,7 +28,7 @@ jobs:
           FOUNDRY_FUZZ_SEED: 0x${{ github.event.pull_request.base.sha || github.sha }}
 
       - name: Compare gas reports
-        uses: Rubilmax/foundry-gas-diff@60e763d02526ee3299bd04278cb178d1547b134b # v3
+        uses: Rubilmax/foundry-gas-diff@v3.21 # v3
         with:
           summaryQuantile: 0.9 # only display the 10% most significant gas diffs in the summary (defaults to 20%)
           sortCriteria: avg,max # sort diff rows by criteria
@@ -38,7 +38,7 @@ jobs:
 
       - name: Add gas diff to sticky comment
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2
+        uses: marocchino/sticky-pull-request-comment@v3.0.2 # v2
         with:
           # delete the comment in case changes no longer impact gas costs
           delete: ${{ !steps.gas_diff.outputs.markdown }}

--- a/.github/workflows/foundry-gas-diff.yml
+++ b/.github/workflows/foundry-gas-diff.yml
@@ -10,7 +10,7 @@ jobs:
   compare_gas_reports:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v6.0.2 # v4
         with:
           submodules: recursive
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
 
       - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@v6.3.0 # v4
         with:
           node-version: '18'
           cache: 'npm'
@@ -32,7 +32,7 @@ jobs:
           npm install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1
+        uses: foundry-rs/foundry-toolchain@v1.7.0 # v1
 
       - name: Show Forge version
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v6.0.2 # v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 for GitHub Actions runtime and will block workflows that rely on older Node runtimes.

This PR updates CI workflows to align with the requirement.

## Changes
- Update reusable action references (`uses:`) to latest released versions.
- Update workflow Node container images (`node:<version>`) to `node:24` where they were below 24.